### PR TITLE
Changed `twitter.com` to `x.com` in `_includes/docs/elements/tw.html` Fixes #3898

### DIFF
--- a/docs/_includes/docs/elements/tw.html
+++ b/docs/_includes/docs/elements/tw.html
@@ -33,13 +33,13 @@
 
   <ul class="bd-tw-actions">
     <li class="bd-tw-action is-reply">
-      <a class="bd-tw-action-link" href="https://twitter.com/intent/tweet?in_reply_to={{ tweet.id }}">
+      <a class="bd-tw-action-link" href="https://x.com/intent/tweet?in_reply_to={{ tweet.id }}">
         <div class="bd-tw-icon"></div>
       </a>
     </li>
 
     <li class="bd-tw-action is-retweet">
-      <a class="bd-tw-action-link" href="https://twitter.com/intent/retweet?tweet_id={{ tweet.id }}">
+      <a class="bd-tw-action-link" href="https://x.com/intent/retweet?tweet_id={{ tweet.id }}">
         <div class="bd-tw-icon"></div>
         {% if tweet.retweets != 0 %}
           <span class="bd-tw-action-stat">
@@ -50,7 +50,7 @@
     </li>
 
     <li class="bd-tw-action is-heart">
-      <a class="bd-tw-action-link" href="https://twitter.com/intent/like?tweet_id={{ tweet.id }}&amp;ref_src=twsrc%5Etfw&amp;ref_url=http%3A%2F%2Fbulma.io%2F&amp;original_referer=http%3A%2F%2Fbulma.io%2F&amp;tw_i={{ tweet.id }}&amp;tw_p=tweetembed" target="_blank">
+      <a class="bd-tw-action-link" href="https://x.com/intent/like?tweet_id={{ tweet.id }}&amp;ref_src=twsrc%5Etfw&amp;ref_url=http%3A%2F%2Fbulma.io%2F&amp;original_referer=http%3A%2F%2Fbulma.io%2F&amp;tw_i={{ tweet.id }}&amp;tw_p=tweetembed" target="_blank">
         <div class="bd-tw-icon"></div>
         {% if tweet.hearts != 0 %}
           <span class="bd-tw-action-stat">


### PR DESCRIPTION

This is a **documentation fix**.

### Proposed solution

Make the twitter cards finally show up with reply & retweet links

### Tradeoffs

None

### Testing Done

None.

<!-- BEFORE SUBMITTING YOUR PR, MAKE SURE TO FOLLOW THESE STEPS: -->
<!-- 1. Pull the latest `master` branch -->
<!-- 2. Make sure your Sass code is compliant with the [Bulma Sass styleguide](https://github.com/jgthms/bulma/blob/master/.github/CONTRIBUTING.md#bulma-sass-styleguide) -->
<!-- 3. Make sure your PR only affects `.sass` or documentation files -->
<!-- 4. [Try your changes](https://github.com/jgthms/bulma/blob/master/.github/CONTRIBUTING.md#try-your-changes). -->

<!-- How have you confirmed this feature works? -->
<!-- Please explain more than "Yes". -->

### Changelog updated?

No.

<!-- Thanks! -->
